### PR TITLE
Update task to use correct Terraform destroy file

### DIFF
--- a/ansible/playbooks/destroy_pulzen_mongocosmosdb_azure.yml
+++ b/ansible/playbooks/destroy_pulzen_mongocosmosdb_azure.yml
@@ -10,4 +10,4 @@
 
   tasks:
     - name: Use role Azure terraform task
-      ansible.builtin.include_tasks: ../roles/gcp/tasks/terraform_pulzen_mongo_atlas_destroy.yml
+      ansible.builtin.include_tasks: ../roles/azure/tasks/terraform_pulzen_mongo_cosmosdb_destroy.yml

--- a/ansible/playbooks/destroy_pulzen_mongocosmosdb_azure.yml
+++ b/ansible/playbooks/destroy_pulzen_mongocosmosdb_azure.yml
@@ -10,4 +10,4 @@
 
   tasks:
     - name: Use role Azure terraform task
-      ansible.builtin.include_tasks: ../roles/gcp/tasks/terraform_pulzen_mongo_atlas_deploy.yml
+      ansible.builtin.include_tasks: ../roles/gcp/tasks/terraform_pulzen_mongo_atlas_destroy.yml


### PR DESCRIPTION
Replaced the deployment task file with the correct destroy task file for MongoDB Atlas. This ensures the playbook accurately performs resource destruction in the Azure environment.